### PR TITLE
Remove redis async support

### DIFF
--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -14,7 +14,7 @@ from collections import namedtuple
 
 SERIES = 'rhubarb'
 
-__version__ = '4.3.0'
+__version__ = '4.3.0.1'
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'
 __homepage__ = 'http://celeryproject.org'

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -224,6 +224,13 @@ class RedisBackend(KeyValueStoreBackend):
 
         self.url = url
 
+        result_backend_transport_opts = self.app.conf.get(
+            "result_backend_transport_options", {})
+        connkwargs = result_backend_transport_opts.get(
+            'CONNECTION_POOL_KWARGS', {})
+        if connkwargs:
+            self.connparams.update(connkwargs)
+
         self.connection_errors, self.channel_errors = (
             get_redis_error_classes() if get_redis_error_classes
             else ((), ()))

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -407,7 +407,7 @@ class RedisBackend(KeyValueStoreBackend):
 
     def _create_client(self, **params):
         return self._get_client()(
-            connection_pool=self._get_pool(**params),
+            connection_pool=self.connection_pool,
         )
 
     def _get_client(self):
@@ -421,6 +421,10 @@ class RedisBackend(KeyValueStoreBackend):
         if self._ConnectionPool is None:
             self._ConnectionPool = self.redis.ConnectionPool
         return self._ConnectionPool
+
+    @cached_property
+    def connection_pool(self):
+        return self._get_pool(**self.connparams)
 
     @cached_property
     def client(self):


### PR DESCRIPTION
The purpose of this change is to eliminate the connection errors and timeouts we've been having with redis. The vast majority of the connection errors we are having occur when we subscribe of unsubscribe to a task result -- a feature we do not use nor need.

Remove `AsyncBackendMixin` from Redis. The async mixin is what causes the redis result backend to create subscriptions, which is where everything has been falling over recently.

While we're in there, also reuse the redis ConnectionPool in order to ensure connection limits are obeyed, and add support for passing arbitrary kwargs to the redis connection pool.